### PR TITLE
schema data model layer, bug fixes in genschema

### DIFF
--- a/applications/monitoring_ui/src/containers/forms/JsonSchemaForm.jsx
+++ b/applications/monitoring_ui/src/containers/forms/JsonSchemaForm.jsx
@@ -60,7 +60,7 @@ class JsonSchemaForm extends React.Component {
     }
 
     //TODO: We should have redux manage this form data's state. For now, clear the form on submit.
-    data.formData={};
+    // data.formData={};
 
     //dispatch the payload to the appropriate api endpoint
     dispatch(sendObcRequest(args, this.props.fnName, this.props.currentRequestType));

--- a/contracts/platform/iotcontractminimalsample/generate.json
+++ b/contracts/platform/iotcontractminimalsample/generate.json
@@ -13,29 +13,31 @@
             "deleteAllAssets",
             "readAsset",
             "readAllAssets",
+            "readAssetStateHistory",
             "readAllRoutes",
             "readWorldState",
             "deleteWorldState",
-            "readAssetStateHistory",
             "readRecentStates",
             "setLoggingLevel",
             "setCreateOnFirstUpdate"
         ],
-        "goSchemaElements": [
+        "Model": [
             "asset"
         ]
     },
     "samples": {
         "goSampleFilename": "samples.go",
-        "goSampleElements": [
+        "API": [
+            "createAsset"
+        ],
+        "Model": [
             "asset",
             "invokeevent",
             "ioteventcommon",
             "assetstate",
             "assetstateexternal",
             "assetstatearray",
-            "stateFilter",
-            "API/createAsset"
+            "stateFilter"
         ]
     }
 }

--- a/contracts/platform/iotcontractminimalsample/main.go
+++ b/contracts/platform/iotcontractminimalsample/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Update the path to match your configuration
-//go:generate go run /local-dev/src/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/scripts/genschema.go
+//go:generate go run /local-dev/src/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/scripts/processSchema.go
 
 // SimpleChaincode is the receiver for all shim API
 type SimpleChaincode struct {
@@ -59,20 +59,6 @@ func (t *SimpleChaincode) Query(stub shim.ChaincodeStubInterface, function strin
 	return iot.Query(stub, function, args)
 }
 
-var overtempAlert iot.AlertName = "OVERTEMP"
-var overtempRule iot.RuleFunc = func(stub shim.ChaincodeStubInterface, asset *iot.Asset) error {
-	temp, found := iot.GetObjectAsNumber(asset.State, "asset.temperature")
-	if found {
-		if temp > 0 {
-			iot.RaiseAlert(asset, overtempAlert)
-		} else {
-			iot.ClearAlert(asset, overtempAlert)
-		}
-	}
-	return nil
-}
-
 func init() {
 	iot.RegisterDefaultRoutes()
-	iot.AddRule("Over Temperature Alert", iot.DefaultClass, []iot.AlertName{overtempAlert}, overtempRule)
 }

--- a/contracts/platform/iotcontractminimalsample/samples.go
+++ b/contracts/platform/iotcontractminimalsample/samples.go
@@ -9,179 +9,57 @@ package main
 var samples = `
 
 {
-    "API/createAsset": {
-        "args": [
-            {
-                "asset": {
-                    "assetID": "An asset's unique ID, barcode, VIN, etc.",
-                    "carrier": "The carrier in possession of this asset",
-                    "common": {
-                        "appdata": [
-                            {
-                                "K": "carpe noctem",
-                                "V": "carpe noctem"
-                            }
-                        ],
-                        "deviceID": "A unique identifier for the device that sent the current event",
-                        "devicetimestamp": "A timestamp recoded by the device that sent the current event",
-                        "location": {
-                            "latitude": 123.456,
-                            "longitude": 123.456
-                        }
-                    },
-                    "temperature": 123.456
-                }
-            }
-        ],
-        "function": "createAsset"
-    },
-    "asset": {
-        "assetID": "An asset's unique ID, barcode, VIN, etc.",
-        "carrier": "The carrier in possession of this asset",
-        "common": {
-            "appdata": [
+    "API": {
+        "createAsset": {
+            "args": [
                 {
-                    "K": "carpe noctem",
-                    "V": "carpe noctem"
+                    "asset": {
+                        "assetID": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                        "carrier": "The carrier in possession of this asset",
+                        "common": {
+                            "appdata": [
+                                {
+                                    "K": "carpe noctem",
+                                    "V": "carpe noctem"
+                                }
+                            ],
+                            "deviceID": "A unique identifier for the device that sent the current event",
+                            "devicetimestamp": "A timestamp recoded by the device that sent the current event",
+                            "location": {
+                                "latitude": 123.456,
+                                "longitude": 123.456
+                            }
+                        },
+                        "temperature": 123.456
+                    }
                 }
             ],
-            "deviceID": "A unique identifier for the device that sent the current event",
-            "devicetimestamp": "A timestamp recoded by the device that sent the current event",
-            "location": {
-                "latitude": 123.456,
-                "longitude": 123.456
-            }
-        },
-        "temperature": 123.456
-    },
-    "assetstate": {
-        "alerts": [
-            ""
-        ],
-        "assetID": "This asset's world state asset ID",
-        "assetIDpath": "Qualified property path to the asset's ID, declared in the contract code",
-        "class": "The asset's asset class",
-        "compliant": true,
-        "eventin": {
-            "asset": {
-                "assetID": "An asset's unique ID, barcode, VIN, etc.",
-                "carrier": "The carrier in possession of this asset",
-                "common": {
-                    "appdata": [
-                        {
-                            "K": "carpe noctem",
-                            "V": "carpe noctem"
-                        }
-                    ],
-                    "deviceID": "A unique identifier for the device that sent the current event",
-                    "devicetimestamp": "A timestamp recoded by the device that sent the current event",
-                    "location": {
-                        "latitude": 123.456,
-                        "longitude": 123.456
-                    }
-                },
-                "temperature": 123.456
-            }
-        },
-        "eventout": {
-            "asset": {
-                "name": "The chaincode event's name",
-                "payload": {}
-            }
-        },
-        "prefix": "The asset's asset class prefix in world state",
-        "state": {
-            "asset": {
-                "assetID": "An asset's unique ID, barcode, VIN, etc.",
-                "carrier": "The carrier in possession of this asset",
-                "common": {
-                    "appdata": [
-                        {
-                            "K": "carpe noctem",
-                            "V": "carpe noctem"
-                        }
-                    ],
-                    "deviceID": "A unique identifier for the device that sent the current event",
-                    "devicetimestamp": "A timestamp recoded by the device that sent the current event",
-                    "location": {
-                        "latitude": 123.456,
-                        "longitude": 123.456
-                    }
-                },
-                "temperature": 123.456
-            }
-        },
-        "txnid": "Transaction UUID matching the blockchain",
-        "txnts": "Transaction timestamp matching the blockchain"
-    },
-    "assetstatearray": [
-        {
-            "^DEF": {
-                "alerts": [
-                    ""
-                ],
-                "assetID": "This asset's world state asset ID",
-                "assetIDpath": "Qualified property path to the asset's ID, declared in the contract code",
-                "class": "The asset's asset class",
-                "compliant": true,
-                "eventin": {
-                    "asset": {
-                        "assetID": "An asset's unique ID, barcode, VIN, etc.",
-                        "carrier": "The carrier in possession of this asset",
-                        "common": {
-                            "appdata": [
-                                {
-                                    "K": "carpe noctem",
-                                    "V": "carpe noctem"
-                                }
-                            ],
-                            "deviceID": "A unique identifier for the device that sent the current event",
-                            "devicetimestamp": "A timestamp recoded by the device that sent the current event",
-                            "location": {
-                                "latitude": 123.456,
-                                "longitude": 123.456
-                            }
-                        },
-                        "temperature": 123.456
-                    }
-                },
-                "eventout": {
-                    "asset": {
-                        "name": "The chaincode event's name",
-                        "payload": {}
-                    }
-                },
-                "prefix": "The asset's asset class prefix in world state",
-                "state": {
-                    "asset": {
-                        "assetID": "An asset's unique ID, barcode, VIN, etc.",
-                        "carrier": "The carrier in possession of this asset",
-                        "common": {
-                            "appdata": [
-                                {
-                                    "K": "carpe noctem",
-                                    "V": "carpe noctem"
-                                }
-                            ],
-                            "deviceID": "A unique identifier for the device that sent the current event",
-                            "devicetimestamp": "A timestamp recoded by the device that sent the current event",
-                            "location": {
-                                "latitude": 123.456,
-                                "longitude": 123.456
-                            }
-                        },
-                        "temperature": 123.456
-                    }
-                },
-                "txnid": "Transaction UUID matching the blockchain",
-                "txnts": "Transaction timestamp matching the blockchain"
-            }
+            "function": "createAsset"
         }
-    ],
-    "assetstateexternal": {
-        "^DEF": {
+    },
+    "Model": {
+        "asset": {
+            "assetID": "An asset's unique ID, e.g. barcode, VIN, etc.",
+            "carrier": "The carrier in possession of this asset",
+            "common": {
+                "appdata": [
+                    {
+                        "K": "carpe noctem",
+                        "V": "carpe noctem"
+                    }
+                ],
+                "deviceID": "A unique identifier for the device that sent the current event",
+                "devicetimestamp": "A timestamp recoded by the device that sent the current event",
+                "location": {
+                    "latitude": 123.456,
+                    "longitude": 123.456
+                }
+            },
+            "temperature": 123.456
+        },
+        "assetstate": {
             "alerts": [
-                ""
+                "An alert name"
             ],
             "assetID": "This asset's world state asset ID",
             "assetIDpath": "Qualified property path to the asset's ID, declared in the contract code",
@@ -189,7 +67,7 @@ var samples = `
             "compliant": true,
             "eventin": {
                 "asset": {
-                    "assetID": "An asset's unique ID, barcode, VIN, etc.",
+                    "assetID": "An asset's unique ID, e.g. barcode, VIN, etc.",
                     "carrier": "The carrier in possession of this asset",
                     "common": {
                         "appdata": [
@@ -217,7 +95,7 @@ var samples = `
             "prefix": "The asset's asset class prefix in world state",
             "state": {
                 "asset": {
-                    "assetID": "An asset's unique ID, barcode, VIN, etc.",
+                    "assetID": "An asset's unique ID, e.g. barcode, VIN, etc.",
                     "carrier": "The carrier in possession of this asset",
                     "common": {
                         "appdata": [
@@ -238,34 +116,99 @@ var samples = `
             },
             "txnid": "Transaction UUID matching the blockchain",
             "txnts": "Transaction timestamp matching the blockchain"
-        }
-    },
-    "invokeevent": {
-        "name": "The chaincode event's name",
-        "payload": {}
-    },
-    "ioteventcommon": {
-        "appdata": [
+        },
+        "assetstatearray": [
             {
-                "K": "carpe noctem",
-                "V": "carpe noctem"
+                "alerts": [
+                    "An alert name"
+                ],
+                "assetID": "This asset's world state asset ID",
+                "assetIDpath": "Qualified property path to the asset's ID, declared in the contract code",
+                "class": "The asset's asset class",
+                "compliant": true,
+                "eventin": {
+                    "asset": {
+                        "assetID": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                        "carrier": "The carrier in possession of this asset",
+                        "common": {
+                            "appdata": [
+                                {
+                                    "K": "carpe noctem",
+                                    "V": "carpe noctem"
+                                }
+                            ],
+                            "deviceID": "A unique identifier for the device that sent the current event",
+                            "devicetimestamp": "A timestamp recoded by the device that sent the current event",
+                            "location": {
+                                "latitude": 123.456,
+                                "longitude": 123.456
+                            }
+                        },
+                        "temperature": 123.456
+                    }
+                },
+                "eventout": {
+                    "asset": {
+                        "name": "The chaincode event's name",
+                        "payload": {}
+                    }
+                },
+                "prefix": "The asset's asset class prefix in world state",
+                "state": {
+                    "asset": {
+                        "assetID": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                        "carrier": "The carrier in possession of this asset",
+                        "common": {
+                            "appdata": [
+                                {
+                                    "K": "carpe noctem",
+                                    "V": "carpe noctem"
+                                }
+                            ],
+                            "deviceID": "A unique identifier for the device that sent the current event",
+                            "devicetimestamp": "A timestamp recoded by the device that sent the current event",
+                            "location": {
+                                "latitude": 123.456,
+                                "longitude": 123.456
+                            }
+                        },
+                        "temperature": 123.456
+                    }
+                },
+                "txnid": "Transaction UUID matching the blockchain",
+                "txnts": "Transaction timestamp matching the blockchain"
             }
         ],
-        "deviceID": "A unique identifier for the device that sent the current event",
-        "devicetimestamp": "A timestamp recoded by the device that sent the current event",
-        "location": {
-            "latitude": 123.456,
-            "longitude": 123.456
-        }
-    },
-    "stateFilter": {
-        "match": "all",
-        "select": [
-            {
-                "qprop": "Qualified property to compare, for example 'asset.assetID'",
-                "value": "Value to be compared"
+        "assetstateexternal": {
+            "^DEF": "INVALID OBJECT - MISSING PROPERTIES"
+        },
+        "invokeevent": {
+            "name": "The chaincode event's name",
+            "payload": {}
+        },
+        "ioteventcommon": {
+            "appdata": [
+                {
+                    "K": "carpe noctem",
+                    "V": "carpe noctem"
+                }
+            ],
+            "deviceID": "A unique identifier for the device that sent the current event",
+            "devicetimestamp": "A timestamp recoded by the device that sent the current event",
+            "location": {
+                "latitude": 123.456,
+                "longitude": 123.456
             }
-        ]
+        },
+        "stateFilter": {
+            "match": "all",
+            "select": [
+                {
+                    "qprop": "Qualified property to compare, for example 'asset.assetID'",
+                    "value": "Value to be compared"
+                }
+            ]
+        }
     }
 }`
 

--- a/contracts/platform/iotcontractminimalsample/schemas.go
+++ b/contracts/platform/iotcontractminimalsample/schemas.go
@@ -20,7 +20,7 @@ var schemas = `
                                 "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                         "type": "string"
                                     },
                                     "carrier": {
@@ -161,51 +161,11 @@ var schemas = `
                             "asset": {
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                         "type": "string"
                                     }
                                 },
                                 "type": "object"
-                            },
-                            "filter": {
-                                "description": "Filter asset states",
-                                "properties": {
-                                    "match": {
-                                        "description": "Defines how to match properties, missing property always fails match",
-                                        "enum": [
-                                            "n/a",
-                                            "all",
-                                            "any",
-                                            "none"
-                                        ],
-                                        "type": "string"
-                                    },
-                                    "select": {
-                                        "description": "Qualified property names and values match",
-                                        "items": {
-                                            "properties": {
-                                                "qprop": {
-                                                    "description": "Qualified property to compare, for example 'asset.assetID'",
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "description": "Value to be compared",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "qprops": {
-                                "description": "Qualified property names such as common.location",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
                             }
                         },
                         "type": "object"
@@ -233,51 +193,11 @@ var schemas = `
                             "asset": {
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                         "type": "string"
                                     }
                                 },
                                 "type": "object"
-                            },
-                            "filter": {
-                                "description": "Filter asset states",
-                                "properties": {
-                                    "match": {
-                                        "description": "Defines how to match properties, missing property always fails match",
-                                        "enum": [
-                                            "n/a",
-                                            "all",
-                                            "any",
-                                            "none"
-                                        ],
-                                        "type": "string"
-                                    },
-                                    "select": {
-                                        "description": "Qualified property names and values match",
-                                        "items": {
-                                            "properties": {
-                                                "qprop": {
-                                                    "description": "Qualified property to compare, for example 'asset.assetID'",
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "description": "Value to be compared",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "qprops": {
-                                "description": "Qualified property names such as common.location",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
                             }
                         },
                         "type": "object"
@@ -305,41 +225,8 @@ var schemas = `
                             "asset": {
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                         "type": "string"
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "filter": {
-                                "description": "Filter asset states",
-                                "properties": {
-                                    "match": {
-                                        "description": "Defines how to match properties, missing property always fails match",
-                                        "enum": [
-                                            "n/a",
-                                            "all",
-                                            "any",
-                                            "none"
-                                        ],
-                                        "type": "string"
-                                    },
-                                    "select": {
-                                        "description": "Qualified property names and values match",
-                                        "items": {
-                                            "properties": {
-                                                "qprop": {
-                                                    "description": "Qualified property to compare, for example 'asset.assetID'",
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "description": "Value to be compared",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
                                     }
                                 },
                                 "type": "object"
@@ -475,210 +362,202 @@ var schemas = `
                 "result": {
                     "description": "Array of asset states, can mix asset classes",
                     "items": {
-                        "patternProperties": {
-                            "^DEF": {
-                                "description": "The external state of one asset asset, named by its world state ID",
+                        "description": "A asset's complete state",
+                        "properties": {
+                            "alerts": {
+                                "description": "A list of alert names",
+                                "items": {
+                                    "description": "An alert name",
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "assetID": {
+                                "description": "This asset's world state asset ID",
+                                "type": "string"
+                            },
+                            "assetIDpath": {
+                                "description": "Qualified property path to the asset's ID, declared in the contract code",
+                                "type": "string"
+                            },
+                            "class": {
+                                "description": "The asset's asset class",
+                                "type": "string"
+                            },
+                            "compliant": {
+                                "description": "This asset has no active alerts",
+                                "type": "boolean"
+                            },
+                            "eventin": {
+                                "description": "The contract event that created this state, for example updateAsset",
                                 "properties": {
-                                    "alerts": {
-                                        "description": "A list of alert names",
-                                        "items": {
-                                            "description": "An alert name",
-                                            "enum": [
-                                                ""
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    "assetID": {
-                                        "description": "This asset's world state asset ID",
-                                        "type": "string"
-                                    },
-                                    "assetIDpath": {
-                                        "description": "Qualified property path to the asset's ID, declared in the contract code",
-                                        "type": "string"
-                                    },
-                                    "class": {
-                                        "description": "The asset's asset class",
-                                        "type": "string"
-                                    },
-                                    "compliant": {
-                                        "description": "This asset has no active alerts",
-                                        "type": "boolean"
-                                    },
-                                    "eventin": {
-                                        "description": "The contract event that created this state, for example updateAsset",
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                         "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
                                                 "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
                                                         "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
+                                                            "latitude": {
+                                                                "type": "number"
                                                             },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
+                                                            "longitude": {
+                                                                "type": "number"
                                                             }
                                                         },
                                                         "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "eventout": {
-                                        "description": "The chaincode event emitted on invoke exit, if any",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "An chaincode event emitted by a contract invoke",
-                                                "properties": {
-                                                    "name": {
-                                                        "description": "The chaincode event's name",
-                                                        "type": "string"
-                                                    },
-                                                    "payload": {
-                                                        "description": "The chaincode event's properties",
-                                                        "properties": {},
-                                                        "type": "object"
                                                     }
                                                 },
                                                 "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
                                             }
                                         },
+                                        "required": [
+                                            "assetID"
+                                        ],
                                         "type": "object"
-                                    },
-                                    "prefix": {
-                                        "description": "The asset's asset class prefix in world state",
-                                        "type": "string"
-                                    },
-                                    "state": {
-                                        "description": "Properties that have been received or calculated for this asset",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
-                                                "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
-                                                        "type": "string"
-                                                    },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
-                                                        "type": "string"
-                                                    },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
-                                                        "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
-                                                            },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "txnid": {
-                                        "description": "Transaction UUID matching the blockchain",
-                                        "type": "string"
-                                    },
-                                    "txnts": {
-                                        "description": "Transaction timestamp matching the blockchain",
-                                        "type": "string"
                                     }
                                 },
                                 "type": "object"
+                            },
+                            "eventout": {
+                                "description": "The chaincode event emitted on invoke exit, if any",
+                                "properties": {
+                                    "asset": {
+                                        "description": "An chaincode event emitted by a contract invoke",
+                                        "properties": {
+                                            "name": {
+                                                "description": "The chaincode event's name",
+                                                "type": "string"
+                                            },
+                                            "payload": {
+                                                "description": "The chaincode event's properties",
+                                                "properties": {},
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "prefix": {
+                                "description": "The asset's asset class prefix in world state",
+                                "type": "string"
+                            },
+                            "state": {
+                                "description": "Properties that have been received or calculated for this asset",
+                                "properties": {
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                        "properties": {
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
+                                                "properties": {
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
+                                                        "properties": {
+                                                            "latitude": {
+                                                                "type": "number"
+                                                            },
+                                                            "longitude": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "assetID"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "txnid": {
+                                "description": "Transaction UUID matching the blockchain",
+                                "type": "string"
+                            },
+                            "txnts": {
+                                "description": "Transaction timestamp matching the blockchain",
+                                "type": "string"
                             }
                         },
                         "type": "object"
@@ -708,210 +587,202 @@ var schemas = `
                 "result": {
                     "description": "Array of asset states, can mix asset classes",
                     "items": {
-                        "patternProperties": {
-                            "^DEF": {
-                                "description": "The external state of one asset asset, named by its world state ID",
+                        "description": "A asset's complete state",
+                        "properties": {
+                            "alerts": {
+                                "description": "A list of alert names",
+                                "items": {
+                                    "description": "An alert name",
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "assetID": {
+                                "description": "This asset's world state asset ID",
+                                "type": "string"
+                            },
+                            "assetIDpath": {
+                                "description": "Qualified property path to the asset's ID, declared in the contract code",
+                                "type": "string"
+                            },
+                            "class": {
+                                "description": "The asset's asset class",
+                                "type": "string"
+                            },
+                            "compliant": {
+                                "description": "This asset has no active alerts",
+                                "type": "boolean"
+                            },
+                            "eventin": {
+                                "description": "The contract event that created this state, for example updateAsset",
                                 "properties": {
-                                    "alerts": {
-                                        "description": "A list of alert names",
-                                        "items": {
-                                            "description": "An alert name",
-                                            "enum": [
-                                                ""
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    "assetID": {
-                                        "description": "This asset's world state asset ID",
-                                        "type": "string"
-                                    },
-                                    "assetIDpath": {
-                                        "description": "Qualified property path to the asset's ID, declared in the contract code",
-                                        "type": "string"
-                                    },
-                                    "class": {
-                                        "description": "The asset's asset class",
-                                        "type": "string"
-                                    },
-                                    "compliant": {
-                                        "description": "This asset has no active alerts",
-                                        "type": "boolean"
-                                    },
-                                    "eventin": {
-                                        "description": "The contract event that created this state, for example updateAsset",
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                         "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
                                                 "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
                                                         "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
+                                                            "latitude": {
+                                                                "type": "number"
                                                             },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
+                                                            "longitude": {
+                                                                "type": "number"
                                                             }
                                                         },
                                                         "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "eventout": {
-                                        "description": "The chaincode event emitted on invoke exit, if any",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "An chaincode event emitted by a contract invoke",
-                                                "properties": {
-                                                    "name": {
-                                                        "description": "The chaincode event's name",
-                                                        "type": "string"
-                                                    },
-                                                    "payload": {
-                                                        "description": "The chaincode event's properties",
-                                                        "properties": {},
-                                                        "type": "object"
                                                     }
                                                 },
                                                 "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
                                             }
                                         },
+                                        "required": [
+                                            "assetID"
+                                        ],
                                         "type": "object"
-                                    },
-                                    "prefix": {
-                                        "description": "The asset's asset class prefix in world state",
-                                        "type": "string"
-                                    },
-                                    "state": {
-                                        "description": "Properties that have been received or calculated for this asset",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
-                                                "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
-                                                        "type": "string"
-                                                    },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
-                                                        "type": "string"
-                                                    },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
-                                                        "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
-                                                            },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "txnid": {
-                                        "description": "Transaction UUID matching the blockchain",
-                                        "type": "string"
-                                    },
-                                    "txnts": {
-                                        "description": "Transaction timestamp matching the blockchain",
-                                        "type": "string"
                                     }
                                 },
                                 "type": "object"
+                            },
+                            "eventout": {
+                                "description": "The chaincode event emitted on invoke exit, if any",
+                                "properties": {
+                                    "asset": {
+                                        "description": "An chaincode event emitted by a contract invoke",
+                                        "properties": {
+                                            "name": {
+                                                "description": "The chaincode event's name",
+                                                "type": "string"
+                                            },
+                                            "payload": {
+                                                "description": "The chaincode event's properties",
+                                                "properties": {},
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "prefix": {
+                                "description": "The asset's asset class prefix in world state",
+                                "type": "string"
+                            },
+                            "state": {
+                                "description": "Properties that have been received or calculated for this asset",
+                                "properties": {
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                        "properties": {
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
+                                                "properties": {
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
+                                                        "properties": {
+                                                            "latitude": {
+                                                                "type": "number"
+                                                            },
+                                                            "longitude": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "assetID"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "txnid": {
+                                "description": "Transaction UUID matching the blockchain",
+                                "type": "string"
+                            },
+                            "txnts": {
+                                "description": "Transaction timestamp matching the blockchain",
+                                "type": "string"
                             }
                         },
                         "type": "object"
@@ -931,51 +802,11 @@ var schemas = `
                             "asset": {
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                         "type": "string"
                                     }
                                 },
                                 "type": "object"
-                            },
-                            "filter": {
-                                "description": "Filter asset states",
-                                "properties": {
-                                    "match": {
-                                        "description": "Defines how to match properties, missing property always fails match",
-                                        "enum": [
-                                            "n/a",
-                                            "all",
-                                            "any",
-                                            "none"
-                                        ],
-                                        "type": "string"
-                                    },
-                                    "select": {
-                                        "description": "Qualified property names and values match",
-                                        "items": {
-                                            "properties": {
-                                                "qprop": {
-                                                    "description": "Qualified property to compare, for example 'asset.assetID'",
-                                                    "type": "string"
-                                                },
-                                                "value": {
-                                                    "description": "Value to be compared",
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "qprops": {
-                                "description": "Qualified property names such as common.location",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
                             }
                         },
                         "type": "object"
@@ -992,15 +823,12 @@ var schemas = `
                 },
                 "method": "query",
                 "result": {
-                    "description": "The external state of one asset asset, named by its world state ID",
+                    "description": "A asset's complete state",
                     "properties": {
                         "alerts": {
                             "description": "A list of alert names",
                             "items": {
                                 "description": "An alert name",
-                                "enum": [
-                                    ""
-                                ],
                                 "type": "string"
                             },
                             "type": "array"
@@ -1028,7 +856,7 @@ var schemas = `
                                     "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                     "properties": {
                                         "assetID": {
-                                            "description": "An asset's unique ID, barcode, VIN, etc.",
+                                            "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                             "type": "string"
                                         },
                                         "carrier": {
@@ -1122,7 +950,7 @@ var schemas = `
                                     "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                     "properties": {
                                         "assetID": {
-                                            "description": "An asset's unique ID, barcode, VIN, etc.",
+                                            "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                             "type": "string"
                                         },
                                         "carrier": {
@@ -1207,7 +1035,25 @@ var schemas = `
                             "asset": {
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "daterange": {
+                                "description": "if specified, dates must fall in between these values, inclusive",
+                                "properties": {
+                                    "begin": {
+                                        "description": "timestamp formatted yyyy-mm-dd hh:mm:ss",
+                                        "format": "date-time",
+                                        "sample": "yyyy-mm-dd hh:mm:ss",
+                                        "type": "string"
+                                    },
+                                    "end": {
+                                        "description": "timestamp formatted yyyy-mm-dd hh:mm:ss",
+                                        "format": "date-time",
+                                        "sample": "yyyy-mm-dd hh:mm:ss",
                                         "type": "string"
                                     }
                                 },
@@ -1245,18 +1091,8 @@ var schemas = `
                                     }
                                 },
                                 "type": "object"
-                            },
-                            "qprops": {
-                                "description": "Qualified property names such as common.location",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
                             }
                         },
-                        "required": [
-                            "asset"
-                        ],
                         "type": "object"
                     },
                     "maxItems": 1,
@@ -1273,210 +1109,202 @@ var schemas = `
                 "result": {
                     "description": "Array of asset states, can mix asset classes",
                     "items": {
-                        "patternProperties": {
-                            "^DEF": {
-                                "description": "The external state of one asset asset, named by its world state ID",
+                        "description": "A asset's complete state",
+                        "properties": {
+                            "alerts": {
+                                "description": "A list of alert names",
+                                "items": {
+                                    "description": "An alert name",
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "assetID": {
+                                "description": "This asset's world state asset ID",
+                                "type": "string"
+                            },
+                            "assetIDpath": {
+                                "description": "Qualified property path to the asset's ID, declared in the contract code",
+                                "type": "string"
+                            },
+                            "class": {
+                                "description": "The asset's asset class",
+                                "type": "string"
+                            },
+                            "compliant": {
+                                "description": "This asset has no active alerts",
+                                "type": "boolean"
+                            },
+                            "eventin": {
+                                "description": "The contract event that created this state, for example updateAsset",
                                 "properties": {
-                                    "alerts": {
-                                        "description": "A list of alert names",
-                                        "items": {
-                                            "description": "An alert name",
-                                            "enum": [
-                                                ""
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    "assetID": {
-                                        "description": "This asset's world state asset ID",
-                                        "type": "string"
-                                    },
-                                    "assetIDpath": {
-                                        "description": "Qualified property path to the asset's ID, declared in the contract code",
-                                        "type": "string"
-                                    },
-                                    "class": {
-                                        "description": "The asset's asset class",
-                                        "type": "string"
-                                    },
-                                    "compliant": {
-                                        "description": "This asset has no active alerts",
-                                        "type": "boolean"
-                                    },
-                                    "eventin": {
-                                        "description": "The contract event that created this state, for example updateAsset",
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                         "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
                                                 "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
                                                         "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
+                                                            "latitude": {
+                                                                "type": "number"
                                                             },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
+                                                            "longitude": {
+                                                                "type": "number"
                                                             }
                                                         },
                                                         "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "eventout": {
-                                        "description": "The chaincode event emitted on invoke exit, if any",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "An chaincode event emitted by a contract invoke",
-                                                "properties": {
-                                                    "name": {
-                                                        "description": "The chaincode event's name",
-                                                        "type": "string"
-                                                    },
-                                                    "payload": {
-                                                        "description": "The chaincode event's properties",
-                                                        "properties": {},
-                                                        "type": "object"
                                                     }
                                                 },
                                                 "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
                                             }
                                         },
+                                        "required": [
+                                            "assetID"
+                                        ],
                                         "type": "object"
-                                    },
-                                    "prefix": {
-                                        "description": "The asset's asset class prefix in world state",
-                                        "type": "string"
-                                    },
-                                    "state": {
-                                        "description": "Properties that have been received or calculated for this asset",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
-                                                "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
-                                                        "type": "string"
-                                                    },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
-                                                        "type": "string"
-                                                    },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
-                                                        "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
-                                                            },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "txnid": {
-                                        "description": "Transaction UUID matching the blockchain",
-                                        "type": "string"
-                                    },
-                                    "txnts": {
-                                        "description": "Transaction timestamp matching the blockchain",
-                                        "type": "string"
                                     }
                                 },
                                 "type": "object"
+                            },
+                            "eventout": {
+                                "description": "The chaincode event emitted on invoke exit, if any",
+                                "properties": {
+                                    "asset": {
+                                        "description": "An chaincode event emitted by a contract invoke",
+                                        "properties": {
+                                            "name": {
+                                                "description": "The chaincode event's name",
+                                                "type": "string"
+                                            },
+                                            "payload": {
+                                                "description": "The chaincode event's properties",
+                                                "properties": {},
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "prefix": {
+                                "description": "The asset's asset class prefix in world state",
+                                "type": "string"
+                            },
+                            "state": {
+                                "description": "Properties that have been received or calculated for this asset",
+                                "properties": {
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                        "properties": {
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
+                                                "properties": {
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
+                                                        "properties": {
+                                                            "latitude": {
+                                                                "type": "number"
+                                                            },
+                                                            "longitude": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "assetID"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "txnid": {
+                                "description": "Transaction UUID matching the blockchain",
+                                "type": "string"
+                            },
+                            "txnts": {
+                                "description": "Transaction timestamp matching the blockchain",
+                                "type": "string"
                             }
                         },
                         "type": "object"
@@ -1518,210 +1346,202 @@ var schemas = `
                 "result": {
                     "description": "Array of asset states, can mix asset classes",
                     "items": {
-                        "patternProperties": {
-                            "^DEF": {
-                                "description": "The external state of one asset asset, named by its world state ID",
+                        "description": "A asset's complete state",
+                        "properties": {
+                            "alerts": {
+                                "description": "A list of alert names",
+                                "items": {
+                                    "description": "An alert name",
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "assetID": {
+                                "description": "This asset's world state asset ID",
+                                "type": "string"
+                            },
+                            "assetIDpath": {
+                                "description": "Qualified property path to the asset's ID, declared in the contract code",
+                                "type": "string"
+                            },
+                            "class": {
+                                "description": "The asset's asset class",
+                                "type": "string"
+                            },
+                            "compliant": {
+                                "description": "This asset has no active alerts",
+                                "type": "boolean"
+                            },
+                            "eventin": {
+                                "description": "The contract event that created this state, for example updateAsset",
                                 "properties": {
-                                    "alerts": {
-                                        "description": "A list of alert names",
-                                        "items": {
-                                            "description": "An alert name",
-                                            "enum": [
-                                                ""
-                                            ],
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    "assetID": {
-                                        "description": "This asset's world state asset ID",
-                                        "type": "string"
-                                    },
-                                    "assetIDpath": {
-                                        "description": "Qualified property path to the asset's ID, declared in the contract code",
-                                        "type": "string"
-                                    },
-                                    "class": {
-                                        "description": "The asset's asset class",
-                                        "type": "string"
-                                    },
-                                    "compliant": {
-                                        "description": "This asset has no active alerts",
-                                        "type": "boolean"
-                                    },
-                                    "eventin": {
-                                        "description": "The contract event that created this state, for example updateAsset",
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                         "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
                                                 "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
                                                         "type": "string"
                                                     },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
                                                         "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
+                                                            "latitude": {
+                                                                "type": "number"
                                                             },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
+                                                            "longitude": {
+                                                                "type": "number"
                                                             }
                                                         },
                                                         "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "eventout": {
-                                        "description": "The chaincode event emitted on invoke exit, if any",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "An chaincode event emitted by a contract invoke",
-                                                "properties": {
-                                                    "name": {
-                                                        "description": "The chaincode event's name",
-                                                        "type": "string"
-                                                    },
-                                                    "payload": {
-                                                        "description": "The chaincode event's properties",
-                                                        "properties": {},
-                                                        "type": "object"
                                                     }
                                                 },
                                                 "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
                                             }
                                         },
+                                        "required": [
+                                            "assetID"
+                                        ],
                                         "type": "object"
-                                    },
-                                    "prefix": {
-                                        "description": "The asset's asset class prefix in world state",
-                                        "type": "string"
-                                    },
-                                    "state": {
-                                        "description": "Properties that have been received or calculated for this asset",
-                                        "properties": {
-                                            "asset": {
-                                                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
-                                                "properties": {
-                                                    "assetID": {
-                                                        "description": "An asset's unique ID, barcode, VIN, etc.",
-                                                        "type": "string"
-                                                    },
-                                                    "carrier": {
-                                                        "description": "The carrier in possession of this asset",
-                                                        "type": "string"
-                                                    },
-                                                    "common": {
-                                                        "description": "Common properties for all assets",
-                                                        "properties": {
-                                                            "appdata": {
-                                                                "description": "Application managed information as an array of key:value pairs",
-                                                                "items": {
-                                                                    "properties": {
-                                                                        "K": {
-                                                                            "type": "string"
-                                                                        },
-                                                                        "V": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "type": "object"
-                                                                },
-                                                                "minItems": 0,
-                                                                "type": "array"
-                                                            },
-                                                            "deviceID": {
-                                                                "description": "A unique identifier for the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "devicetimestamp": {
-                                                                "description": "A timestamp recoded by the device that sent the current event",
-                                                                "type": "string"
-                                                            },
-                                                            "location": {
-                                                                "description": "A geographical coordinate",
-                                                                "properties": {
-                                                                    "latitude": {
-                                                                        "type": "number"
-                                                                    },
-                                                                    "longitude": {
-                                                                        "type": "number"
-                                                                    }
-                                                                },
-                                                                "type": "object"
-                                                            }
-                                                        },
-                                                        "type": "object"
-                                                    },
-                                                    "temperature": {
-                                                        "description": "Temperature of an asset's contents in degrees Celsuis",
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "assetID"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "txnid": {
-                                        "description": "Transaction UUID matching the blockchain",
-                                        "type": "string"
-                                    },
-                                    "txnts": {
-                                        "description": "Transaction timestamp matching the blockchain",
-                                        "type": "string"
                                     }
                                 },
                                 "type": "object"
+                            },
+                            "eventout": {
+                                "description": "The chaincode event emitted on invoke exit, if any",
+                                "properties": {
+                                    "asset": {
+                                        "description": "An chaincode event emitted by a contract invoke",
+                                        "properties": {
+                                            "name": {
+                                                "description": "The chaincode event's name",
+                                                "type": "string"
+                                            },
+                                            "payload": {
+                                                "description": "The chaincode event's properties",
+                                                "properties": {},
+                                                "type": "object"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "prefix": {
+                                "description": "The asset's asset class prefix in world state",
+                                "type": "string"
+                            },
+                            "state": {
+                                "description": "Properties that have been received or calculated for this asset",
+                                "properties": {
+                                    "asset": {
+                                        "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                                        "properties": {
+                                            "assetID": {
+                                                "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
+                                                "type": "string"
+                                            },
+                                            "carrier": {
+                                                "description": "The carrier in possession of this asset",
+                                                "type": "string"
+                                            },
+                                            "common": {
+                                                "description": "Common properties for all assets",
+                                                "properties": {
+                                                    "appdata": {
+                                                        "description": "Application managed information as an array of key:value pairs",
+                                                        "items": {
+                                                            "properties": {
+                                                                "K": {
+                                                                    "type": "string"
+                                                                },
+                                                                "V": {
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object"
+                                                        },
+                                                        "minItems": 0,
+                                                        "type": "array"
+                                                    },
+                                                    "deviceID": {
+                                                        "description": "A unique identifier for the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "devicetimestamp": {
+                                                        "description": "A timestamp recoded by the device that sent the current event",
+                                                        "type": "string"
+                                                    },
+                                                    "location": {
+                                                        "description": "A geographical coordinate",
+                                                        "properties": {
+                                                            "latitude": {
+                                                                "type": "number"
+                                                            },
+                                                            "longitude": {
+                                                                "type": "number"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            "temperature": {
+                                                "description": "Temperature of an asset's contents in degrees Celsuis",
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "assetID"
+                                        ],
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "txnid": {
+                                "description": "Transaction UUID matching the blockchain",
+                                "type": "string"
+                            },
+                            "txnts": {
+                                "description": "Transaction timestamp matching the blockchain",
+                                "type": "string"
                             }
                         },
                         "type": "object"
@@ -1765,7 +1585,7 @@ var schemas = `
                                 "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                         "type": "string"
                                     },
                                     "carrier": {
@@ -1912,7 +1732,7 @@ var schemas = `
                                 "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
                                 "properties": {
                                     "assetID": {
-                                        "description": "An asset's unique ID, barcode, VIN, etc.",
+                                        "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                                         "type": "string"
                                     },
                                     "carrier": {
@@ -1989,12 +1809,12 @@ var schemas = `
             "type": "object"
         }
     },
-    "objectModelSchemas": {
+    "Model": {
         "asset": {
             "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
             "properties": {
                 "assetID": {
-                    "description": "An asset's unique ID, barcode, VIN, etc.",
+                    "description": "An asset's unique ID, e.g. barcode, VIN, etc.",
                     "type": "string"
                 },
                 "carrier": {

--- a/contracts/platform/iotcontractminimalsample/vendor/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/ctalerts.go
+++ b/contracts/platform/iotcontractminimalsample/vendor/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/ctalerts.go
@@ -18,9 +18,7 @@ Kim Letkeman - Initial Contribution
 
 package iotcontractplatform
 
-import (
-	"sort"
-)
+import "sort"
 
 // AlertNameArray is a string that represents an alert
 type AlertNameArray []AlertName

--- a/contracts/platform/iotcontractminimalsample/vendor/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/cthistory.go
+++ b/contracts/platform/iotcontractminimalsample/vendor/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/cthistory.go
@@ -51,10 +51,10 @@ var EmptyDateRange = DateRange{}
 
 // DateRange allows a function to return states between a begin and end time, inclusive
 type DateRange struct {
-	Range struct {
+	DateRange struct {
 		Begin string `json:"begin"`
 		End   string `json:"end"`
-	} `json:"range"`
+	} `json:"daterange"`
 }
 
 // PUTAssetStateHistory write an Asset state with history key
@@ -159,8 +159,8 @@ func (c *AssetClass) ReadAssetStateHistory(stub shim.ChaincodeStubInterface, arg
 		begin = ""
 		end = "}"
 	} else {
-		begin = dr.Range.Begin
-		end = dr.Range.End + "}"
+		begin = dr.DateRange.Begin
+		end = dr.DateRange.End + "}"
 	}
 
 	var historyKey = STATEHISTORYKEY + assetKey + "."

--- a/contracts/platform/iotcontractminimalsample/vendor/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/ctmaps.go
+++ b/contracts/platform/iotcontractminimalsample/vendor/github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform/ctmaps.go
@@ -321,10 +321,9 @@ func GetObjectAsInteger(objIn *map[string]interface{}, qname string) (int, bool)
 func Contains(arr interface{}, val interface{}) bool {
 	switch arr.(type) {
 	case AlertNameArray:
-		fmt.Printf("CONTAINS AlertNameArray\n")
 		arr2 := arr.(AlertNameArray)
 		for _, v := range arr2 {
-			if string(v) == val {
+			if reflect.DeepEqual(v, val) {
 				return true
 			}
 		}

--- a/contracts/platform/iotcontractminimalsample/vendor/vendor.json
+++ b/contracts/platform/iotcontractminimalsample/vendor/vendor.json
@@ -97,10 +97,10 @@
 			"revisionTime": "2016-11-07T20:42:32Z"
 		},
 		{
-			"checksumSHA1": "I+zjLJ3LpW4cO/SnfXqiTxAZ7bc=",
+			"checksumSHA1": "SwlLXEv97xxIr5MDoJk0+ypn0Y0=",
 			"path": "github.com/ibm-watson-iot/blockchain-samples/contracts/platform/iotcontractplatform",
-			"revision": "9fa718d44f5b81aea4788f81dcf3e7e0d015bdd9",
-			"revisionTime": "2016-11-17T10:32:42Z"
+			"revision": "9c306255b4963f7d73ccf70beb8ed64c49da7151",
+			"revisionTime": "2016-11-18T18:00:24Z"
 		},
 		{
 			"checksumSHA1": "1YeGotQXMZMqk+mmm8sbBVJywpw=",

--- a/contracts/platform/iotcontractplatform/ctalerts.go
+++ b/contracts/platform/iotcontractplatform/ctalerts.go
@@ -18,9 +18,7 @@ Kim Letkeman - Initial Contribution
 
 package iotcontractplatform
 
-import (
-	"sort"
-)
+import "sort"
 
 // AlertNameArray is a string that represents an alert
 type AlertNameArray []AlertName

--- a/contracts/platform/iotcontractplatform/cthistory.go
+++ b/contracts/platform/iotcontractplatform/cthistory.go
@@ -51,10 +51,10 @@ var EmptyDateRange = DateRange{}
 
 // DateRange allows a function to return states between a begin and end time, inclusive
 type DateRange struct {
-	Range struct {
+	DateRange struct {
 		Begin string `json:"begin"`
 		End   string `json:"end"`
-	} `json:"range"`
+	} `json:"daterange"`
 }
 
 // PUTAssetStateHistory write an Asset state with history key
@@ -159,8 +159,8 @@ func (c *AssetClass) ReadAssetStateHistory(stub shim.ChaincodeStubInterface, arg
 		begin = ""
 		end = "}"
 	} else {
-		begin = dr.Range.Begin
-		end = dr.Range.End + "}"
+		begin = dr.DateRange.Begin
+		end = dr.DateRange.End + "}"
 	}
 
 	var historyKey = STATEHISTORYKEY + assetKey + "."

--- a/contracts/platform/iotcontractplatform/ctmaps.go
+++ b/contracts/platform/iotcontractplatform/ctmaps.go
@@ -321,10 +321,9 @@ func GetObjectAsInteger(objIn *map[string]interface{}, qname string) (int, bool)
 func Contains(arr interface{}, val interface{}) bool {
 	switch arr.(type) {
 	case AlertNameArray:
-		fmt.Printf("CONTAINS AlertNameArray\n")
 		arr2 := arr.(AlertNameArray)
 		for _, v := range arr2 {
-			if string(v) == val {
+			if reflect.DeepEqual(v, val) {
 				return true
 			}
 		}

--- a/contracts/platform/iotcontractplatform/schema/IOTCPschema.json
+++ b/contracts/platform/iotcontractplatform/schema/IOTCPschema.json
@@ -4,796 +4,798 @@
     "description": "Watson IoT Hyperledger Smart Contract Platform Schema",
     "definitions": {
         "API": {
-            "type": "object",
-            "description": "Contract API",
-            "properties": {
-                "initContract": {
-                    "type": "object",
-                    "description": "Sets contract version and nickname",
-                    "properties": {
-                        "method": "deploy",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "initContract"
-                            ]
+            "initContract": {
+                "type": "object",
+                "description": "Sets contract version and nickname",
+                "properties": {
+                    "method": "deploy",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "initContract"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "version": {
+                                    "$ref": "#/definitions/Model/version"
+                                },
+                                "nickname": {
+                                    "$ref": "#/definitions/Model/nickname"
+                                }
+                            }
                         },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "version": {
-                                        "$ref": "#/definitions/version"
-                                    },
-                                    "nickname": {
-                                        "$ref": "#/definitions/nickname"
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "createAsset": {
+                "type": "object",
+                "description": "Creates a new asset by class",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "createAsset"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "asset": {
+                                    "$ref": "#/definitions/Model/asset"
+                                }
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "replaceAsset": {
+                "type": "object",
+                "description": "Replaces an asset's state (e.g. put existing)",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "replaceAsset"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "asset": {
+                                    "$ref": "#/definitions/Model/asset"
+                                }
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "updateAsset": {
+                "type": "object",
+                "description": "Update an asset's state with one or more property changes",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "updateAsset"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "asset": {
+                                    "$ref": "#/definitions/Model/asset"
+                                }
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "deleteAsset": {
+                "type": "object",
+                "description": "Delete an asset from world state, transactions remain on the blockchain",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "deleteAsset"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/Model/assetKey"
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "deleteAssetStateHistory": {
+                "type": "object",
+                "description": "Delete an asset's history from world state, transactions remain on the blockchain",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "deleteAssetStateHistory"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/Model/assetKey"
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "deletePropertiesFromAsset": {
+                "type": "object",
+                "description": "Delete one or more properties from an asset's state",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "deletePropertiesFromAsset"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/Model/assetKey",
+                                "qprops": {
+                                    "type": "array",
+                                    "description": "Qualified property names such as common.location",
+                                    "items": {
+                                        "type": "string"
                                     }
                                 }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "createAsset": {
-                    "type": "object",
-                    "description": "Creates a new asset by class",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "createAsset"
-                            ]
+                            }
                         },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "asset": {
-                                        "$ref": "#/definitions/asset"
-                                    }
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "deleteAllAssets": {
+                "type": "object",
+                "description": "Delete all assets from world state, supports filters",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "deleteAllAssets"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "filter": {
+                                    "$ref": "#/definitions/Model/stateFilter"
                                 }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "replaceAsset": {
-                    "type": "object",
-                    "description": "Replaces an asset's state (e.g. put existing)",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "replaceAsset"
-                            ]
+                            }
                         },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "asset": {
-                                        "$ref": "#/definitions/asset"
-                                    }
+                        "minItems": 0,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "readAsset": {
+                "type": "object",
+                "description": "Returns the state an asset",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readAsset"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "$ref": "#/definitions/Model/assetKey"
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    },
+                    "result": {
+                        "$ref": "#/definitions/Model/assetstate"
+                    }
+                }
+            },
+            "readAllAssets": {
+                "type": "object",
+                "description": "Returns the state of all assets, supports filters",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readAllAssets"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "filter": {
+                                    "$ref": "#/definitions/Model/stateFilter"
                                 }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "updateAsset": {
-                    "type": "object",
-                    "description": "Update an asset's state with one or more property changes",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "updateAsset"
-                            ]
+                            }
                         },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "asset": {
-                                        "$ref": "#/definitions/asset"
-                                    }
-                                }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
+                        "minItems": 0,
+                        "maxItems": 1
+                    },
+                    "result": {
+                        "$ref": "#/definitions/Model/assetstatearray"
                     }
-                },
-                "deleteAsset": {
-                    "type": "object",
-                    "description": "Delete an asset from world state, transactions remain on the blockchain",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "deleteAsset"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "$ref": "#/definitions/assetKey"
-                                }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "deleteAssetStateHistory": {
-                    "type": "object",
-                    "description": "Delete an asset's history from world state, transactions remain on the blockchain",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "deleteAssetStateHistory"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "$ref": "#/definitions/assetKey"
-                                }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "deletePropertiesFromAsset": {
-                    "type": "object",
-                    "description": "Delete one or more properties from an asset's state",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "deletePropertiesFromAsset"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "$ref": "#/definitions/assetKey",
-                                    "qprops": {
-                                        "type": "array",
-                                        "description": "Qualified property names such as common.location",
-                                        "items": {
-                                            "type": "string"
+                }
+            },
+            "readAssetStateHistory": {
+                "type": "object",
+                "description": "Returns history for an asset",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readAssetStateHistory"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "asset": {
+                                    "type": "object",
+                                    "properties": {
+                                        "assetID": {
+                                            "$ref": "#/definitions/Model/assetID"
                                         }
-                                    }
-                                }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "deleteAllAssets": {
-                    "type": "object",
-                    "description": "Delete all assets from world state, supports filters",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "deleteAllAssets"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "filter": {
-                                        "$ref": "#/definitions/stateFilter"
-                                    }
-                                }
-                            },
-                            "minItems": 0,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "readAsset": {
-                    "type": "object",
-                    "description": "Returns the state an asset",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readAsset"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "$ref": "#/definitions/assetKey"
-                                }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        },
-                        "result": {
-                            "$ref": "#/definitions/assetstate"
-                        }
-                    }
-                },
-                "readAllAssets": {
-                    "type": "object",
-                    "description": "Returns the state of all assets, supports filters",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readAllAssets"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "filter": {
-                                        "$ref": "#/definitions/stateFilter"
-                                    }
-                                }
-                            },
-                            "minItems": 0,
-                            "maxItems": 1
-                        },
-                        "result": {
-                            "$ref": "#/definitions/assetstatearray"
-                        }
-                    }
-                },
-                "readAssetStateHistory": {
-                    "type": "object",
-                    "description": "Returns history for an asset",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readAssetStateHistory"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "$ref": "#/definitions/assetKey",
-                                    "range": {
-                                        "type": "object",
-                                        "description": "if specified, dates must fall in between these values, inclusive",
-                                        "properties": {
-                                            "begin": {
-                                                "type": "string",
-                                                "description": "timestamp formatted yyyy-mm-dd hh:mm:ss",
-                                                "format": "date-time",
-                                                "sample": "yyyy-mm-dd hh:mm:ss"
-                                            },
-                                            "end": {
-                                                "type": "string",
-                                                "description": "timestamp formatted yyyy-mm-dd hh:mm:ss",
-                                                "format": "date-time",
-                                                "sample": "yyyy-mm-dd hh:mm:ss"
-                                            }
-                                        }
-                                    },
-                                    "filter": {
-                                        "$ref": "#/definitions/stateFilter"
                                     }
                                 },
-                                "required": [
-                                    "asset"
-                                ]
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        },
-                        "result": {
-                            "$ref": "#/definitions/assetstatearray"
-                        }
-                    }
-                },
-                "readAssetSchemas": {
-                    "type": "object",
-                    "description": "Returns the API for this contract for the use of self-configuring applications; is MANDATORY for integration with the Watson IoT Platform",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readAssetSchemas"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {},
-                            "minItems": 0,
-                            "maxItems": 0
-                        },
-                        "result": {
-                            "type": "object",
-                            "properties": {}
-                        }
-                    }
-                },
-                "readAssetSamples": {
-                    "type": "object",
-                    "description": "Returns samples of selected contract objects",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readAssetSamples"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {},
-                            "minItems": 0,
-                            "maxItems": 0
-                        },
-                        "result": {
-                            "type": "object",
-                            "properties": {}
-                        }
-                    }
-                },
-                "readRecentStates": {
-                    "type": "object",
-                    "description": "Returns the state of recently updated assets",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readRecentStates"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "begin": {
-                                        "type": "integer",
-                                        "description": "zero based beginning of range"
-                                    },
-                                    "end": {
-                                        "type": "integer",
-                                        "description": "zero based end of range, absence means to end"
-                                    }
+                                "daterange": {
+                                    "$ref": "#/definitions/Model/dateRange"
+                                },
+                                "filter": {
+                                    "$ref": "#/definitions/Model/stateFilter"
                                 }
-                            },
-                            "minItems": 0,
-                            "maxItems": 0
+                            }
                         },
-                        "result": {
-                            "$ref": "#/definitions/assetstatearray"
-                        }
+                        "minItems": 1,
+                        "maxItems": 1
+                    },
+                    "result": {
+                        "$ref": "#/definitions/Model/assetstatearray"
                     }
-                },
-                "readAllRoutes": {
-                    "type": "object",
-                    "description": "Returns an array of registered API calls by function (debugging)",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readAllRoutes"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {},
-                            "minItems": 0,
-                            "maxItems": 0
-                        },
-                        "result": {
-                            "$ref": "#/definitions/assetstatearray"
-                        }
+                }
+            },
+            "readAssetSchemas": {
+                "type": "object",
+                "description": "Returns the API for this contract for the use of self-configuring applications; is MANDATORY for integration with the Watson IoT Platform",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readAssetSchemas"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {},
+                        "minItems": 0,
+                        "maxItems": 0
+                    },
+                    "result": {
+                        "type": "object",
+                        "properties": {}
                     }
-                },
-                "readContractState": {
-                    "type": "object",
-                    "description": "Returns this contract instance's version and nickname",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readContractState"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {},
-                            "minItems": 0,
-                            "maxItems": 0
-                        },
-                        "result": {
-                            "$ref": "#/definitions/contractState"
-                        }
+                }
+            },
+            "readAssetSamples": {
+                "type": "object",
+                "description": "Returns samples of selected contract objects",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readAssetSamples"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {},
+                        "minItems": 0,
+                        "maxItems": 0
+                    },
+                    "result": {
+                        "type": "object",
+                        "properties": {}
                     }
-                },
-                "setLoggingLevel": {
-                    "type": "object",
-                    "description": "Sets the logging level for the contract",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "setLoggingLevel"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "logLevel": {
-                                        "type": "string",
-                                        "enum": [
-                                            "CRITICAL",
-                                            "ERROR",
-                                            "WARNING",
-                                            "NOTICE",
-                                            "INFO",
-                                            "DEBUG"
-                                        ]
-                                    }
-                                }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "setCreateOnFirstUpdate": {
-                    "type": "object",
-                    "description": "Allow updateAsset to create an asset upon receipt of its first event",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "setCreateOnFirstUpdate"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "setCreateOnFirstUpdate": {
-                                        "type": "boolean",
-                                        "description": "Allows updates to create missing assets on first event"
-                                    }
-                                }
-                            },
-                            "minItems": 1,
-                            "maxItems": 1
-                        }
-                    }
-                },
-                "readWorldState": {
-                    "type": "object",
-                    "description": "Returns the entire contents of world state",
-                    "properties": {
-                        "method": "query",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "readWorldState"
-                            ]
-                        },
-                        "args": {
-                            "type": "array",
-                            "items": {},
-                            "minItems": 0,
-                            "maxItems": 0
-                        },
-                        "result": {
+                }
+            },
+            "readRecentStates": {
+                "type": "object",
+                "description": "Returns the state of recently updated assets",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readRecentStates"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
                             "type": "object",
-                            "properties": {}
-                        }
-                    }
-                },
-                "deleteWorldState": {
-                    "type": "object",
-                    "description": "**** WARNING *** Clears the entire contents of world state, redeploy the contract after using this, in debugging mode, will require a restart",
-                    "properties": {
-                        "method": "invoke",
-                        "function": {
-                            "type": "string",
-                            "enum": [
-                                "deleteWorldState"
-                            ]
+                            "properties": {
+                                "begin": {
+                                    "type": "integer",
+                                    "description": "zero based beginning of range"
+                                },
+                                "end": {
+                                    "type": "integer",
+                                    "description": "zero based end of range, absence means to end"
+                                }
+                            }
                         },
-                        "args": {
-                            "type": "array",
-                            "items": {},
-                            "minItems": 0,
-                            "maxItems": 0
-                        }
+                        "minItems": 0,
+                        "maxItems": 0
+                    },
+                    "result": {
+                        "$ref": "#/definitions/Model/assetstatearray"
+                    }
+                }
+            },
+            "readAllRoutes": {
+                "type": "object",
+                "description": "Returns an array of registered API calls by function (debugging)",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readAllRoutes"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {},
+                        "minItems": 0,
+                        "maxItems": 0
+                    },
+                    "result": {
+                        "$ref": "#/definitions/Model/assetstatearray"
+                    }
+                }
+            },
+            "readContractState": {
+                "type": "object",
+                "description": "Returns this contract instance's version and nickname",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readContractState"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {},
+                        "minItems": 0,
+                        "maxItems": 0
+                    },
+                    "result": {
+                        "$ref": "#/definitions/Model/contractState"
+                    }
+                }
+            },
+            "setLoggingLevel": {
+                "type": "object",
+                "description": "Sets the logging level for the contract",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "setLoggingLevel"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "logLevel": {
+                                    "type": "string",
+                                    "enum": [
+                                        "CRITICAL",
+                                        "ERROR",
+                                        "WARNING",
+                                        "NOTICE",
+                                        "INFO",
+                                        "DEBUG"
+                                    ]
+                                }
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "setCreateOnFirstUpdate": {
+                "type": "object",
+                "description": "Allow updateAsset to create an asset upon receipt of its first event",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "setCreateOnFirstUpdate"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "setCreateOnFirstUpdate": {
+                                    "type": "boolean",
+                                    "description": "Allows updates to create missing assets on first event"
+                                }
+                            }
+                        },
+                        "minItems": 1,
+                        "maxItems": 1
+                    }
+                }
+            },
+            "readWorldState": {
+                "type": "object",
+                "description": "Returns the entire contents of world state",
+                "properties": {
+                    "method": "query",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "readWorldState"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {},
+                        "minItems": 0,
+                        "maxItems": 0
+                    },
+                    "result": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            },
+            "deleteWorldState": {
+                "type": "object",
+                "description": "**** WARNING *** Clears the entire contents of world state, redeploy the contract after using this, in debugging mode, will require a restart",
+                "properties": {
+                    "method": "invoke",
+                    "function": {
+                        "type": "string",
+                        "enum": [
+                            "deleteWorldState"
+                        ]
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": {},
+                        "minItems": 0,
+                        "maxItems": 0
                     }
                 }
             }
         },
-        "version": {
-            "type": "string",
-            "description": "The version number of the current contract instance"
-        },
-        "nickname": {
-            "type": "string",
-            "default": "IOT Contract Platform",
-            "description": "The nickname of the current contract instance"
-        },
-        "assetID": {
-            "type": "string",
-            "description": "An asset's unique ID, barcode, VIN, etc."
-        },
-        "assetKey": {
-            "asset": {
+        "Model": {
+            "version": {
+                "type": "string",
+                "description": "The version number of the current contract instance"
+            },
+            "nickname": {
+                "type": "string",
+                "default": "IOT Contract Platform",
+                "description": "The nickname of the current contract instance"
+            },
+            "assetID": {
+                "type": "string",
+                "description": "An asset's unique ID, e.g. barcode, VIN, etc."
+            },
+            "assetKey": {
+                "asset": {
+                    "type": "object",
+                    "properties": {
+                        "assetID": {
+                            "$ref": "#/definitions/Model/assetID"
+                        }
+                    }
+                }
+            },
+            "alertName": {
+                "type": "string",
+                "description": "An alert name"
+            },
+            "alerts": {
+                "type": "array",
+                "description": "A list of alert names",
+                "items": {
+                    "$ref": "#/definitions/Model/alertName"
+                }
+            },
+            "geo": {
+                "description": "A geographical coordinate",
                 "type": "object",
                 "properties": {
+                    "latitude": { "type": "number" },
+                    "longitude": { "type": "number" }
+                }
+            },
+            "asset": {
+                "type": "object",
+                "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
+                "properties": {
+                    "common": {
+                        "$ref": "#/definitions/Model/ioteventcommon"
+                    },
                     "assetID": {
-                        "$ref": "#/definitions/assetID"
+                        "$ref": "#/definitions/Model/assetID"
+                    },
+                    "temperature": {
+                        "type": "number",
+                        "description": "Temperature of an asset's contents in degrees Celsuis"
+                    },
+                    "carrier": {
+                        "type": "string",
+                        "description": "The carrier in possession of this asset"
+                    }
+                },
+                "required": [
+                    "assetID"
+                ]
+            },
+            "invokeevent": {
+                "type": "object",
+                "description": "An chaincode event emitted by a contract invoke",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The chaincode event's name"
+                    },
+                    "payload": {
+                        "type": "object",
+                        "description": "The chaincode event's properties",
+                        "properties": {}
                     }
                 }
-            }
-        },
-        "alertName": {
-            "type": "string",
-            "enum": [
-                ""
-            ],
-            "description": "An alert name"
-        },
-        "alerts": {
-            "type": "array",
-            "description": "A list of alert names",
-            "items": {
-                "$ref": "#/definitions/alertName"
-            }
-        },
-        "geo": {
-            "description": "A geographical coordinate",
-            "type": "object",
-            "properties": {
-                "latitude": { "type": "number" },
-                "longitude": { "type": "number" }
-            }
-        },
-        "asset": {
-            "type": "object",
-            "description": "The changeable properties for an asset, also considered its 'event' as a partial state",
-            "properties": {
-                "common": {
-                    "$ref": "#/definitions/ioteventcommon"
-                },
-                "assetID": {
-                    "$ref": "#/definitions/assetID"
-                },
-                "temperature": {
-                    "type": "number",
-                    "description": "Temperature of an asset's contents in degrees Celsuis"
-                },
-                "carrier": {
-                    "type": "string",
-                    "description": "The carrier in possession of this asset"
-                }
             },
-            "required": [
-                "assetID"
-            ]
-        },
-        "invokeevent": {
-            "type": "object",
-            "description": "An chaincode event emitted by a contract invoke",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "The chaincode event's name"
-                },
-                "payload": {
-                    "type": "object",
-                    "description": "The chaincode event's properties",
-                    "properties": {}
-                }
-            }
-        },
-        "ioteventcommon": {
-            "type": "object",
-            "description": "Common properties for all assets",
-            "properties": {
-                "devicetimestamp": {
-                    "type": "string",
-                    "description": "A timestamp recoded by the device that sent the current event"
-                },
-                "deviceID": {
-                    "type": "string",
-                    "description": "A unique identifier for the device that sent the current event"
-                },
-                "location": {
-                    "$ref": "#/definitions/geo"
-                },
-                "appdata": {
-                    "type": "array",
-                    "description": "Application managed information as an array of key:value pairs",
-                    "minItems": 0,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "K": {
-                                "type": "string"
-                            },
-                            "V": {
-                                "type": "string"
+            "ioteventcommon": {
+                "type": "object",
+                "description": "Common properties for all assets",
+                "properties": {
+                    "devicetimestamp": {
+                        "type": "string",
+                        "description": "A timestamp recoded by the device that sent the current event"
+                    },
+                    "deviceID": {
+                        "type": "string",
+                        "description": "A unique identifier for the device that sent the current event"
+                    },
+                    "location": {
+                        "$ref": "#/definitions/Model/geo"
+                    },
+                    "appdata": {
+                        "type": "array",
+                        "description": "Application managed information as an array of key:value pairs",
+                        "minItems": 0,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "K": {
+                                    "type": "string"
+                                },
+                                "V": {
+                                    "type": "string"
+                                }
                             }
                         }
                     }
                 }
-            }
-        },
-        "assetstate": {
-            "type": "object",
-            "description": "A asset's complete state",
-            "properties": {
-                "class": {
-                    "type": "string",
-                    "description": "The asset's asset class"
-                },
-                "prefix": {
-                    "type": "string",
-                    "description": "The asset's asset class prefix in world state"
-                },
-                "assetIDpath": {
-                    "type": "string",
-                    "description": "Qualified property path to the asset's ID, declared in the contract code"
-                },
-                "assetID": {
-                    "type": "string",
-                    "description": "This asset's world state asset ID"
-                },
-                "state": {
-                    "type": "object",
-                    "description": "Properties that have been received or calculated for this asset",
-                    "properties": {
-                        "asset": {
-                            "$ref": "#/definitions/asset"
-                        }
-                    }
-                },
-                "eventin": {
-                    "type": "object",
-                    "description": "The contract event that created this state, for example updateAsset",
-                    "properties": {
-                        "asset": {
-                            "$ref": "#/definitions/asset"
-                        }
-                    }
-                },
-                "txnts": {
-                    "type": "string",
-                    "description": "Transaction timestamp matching the blockchain"
-                },
-                "txnid": {
-                    "type": "string",
-                    "description": "Transaction UUID matching the blockchain"
-                },
-                "eventout": {
-                    "type": "object",
-                    "description": "The chaincode event emitted on invoke exit, if any",
-                    "properties": {
-                        "asset": {
-                            "$ref": "#/definitions/invokeevent"
-                        }
-                    }
-                },
-                "alerts": {
-                    "$ref": "#/definitions/alerts"
-                },
-                "compliant": {
-                    "type": "boolean",
-                    "description": "This asset has no active alerts"
-                }
-            }
-        },
-        "assetstateexternal": {
-            "type": "object",
-            "patternProperties": {
-                "^DEF": {
-                    "type": "object",
-                    "description": "The external state of one asset asset, named by its world state ID",
-                    "$ref": "#/definitions/assetstate"
-                }
-            }
-        },
-        "stateFilter": {
-            "type": "object",
-            "description": "Filter asset states",
-            "properties": {
-                "match": {
-                    "type": "string",
-                    "description": "Defines how to match properties, missing property always fails match",
-                    "enum": [
-                        "n/a",
-                        "all",
-                        "any",
-                        "none"
-                    ]
-                },
-                "select": {
-                    "type": "array",
-                    "description": "Qualified property names and values match",
-                    "items": {
+            },
+            "assetstate": {
+                "type": "object",
+                "description": "A asset's complete state",
+                "properties": {
+                    "class": {
+                        "type": "string",
+                        "description": "The asset's asset class"
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "The asset's asset class prefix in world state"
+                    },
+                    "assetIDpath": {
+                        "type": "string",
+                        "description": "Qualified property path to the asset's ID, declared in the contract code"
+                    },
+                    "assetID": {
+                        "type": "string",
+                        "description": "This asset's world state asset ID"
+                    },
+                    "state": {
                         "type": "object",
+                        "description": "Properties that have been received or calculated for this asset",
                         "properties": {
-                            "qprop": {
-                                "type": "string",
-                                "description": "Qualified property to compare, for example 'asset.assetID'"
-                            },
-                            "value": {
-                                "type": "string",
-                                "description": "Value to be compared"
+                            "asset": {
+                                "$ref": "#/definitions/Model/asset"
+                            }
+                        }
+                    },
+                    "eventin": {
+                        "type": "object",
+                        "description": "The contract event that created this state, for example updateAsset",
+                        "properties": {
+                            "asset": {
+                                "$ref": "#/definitions/Model/asset"
+                            }
+                        }
+                    },
+                    "txnts": {
+                        "type": "string",
+                        "description": "Transaction timestamp matching the blockchain"
+                    },
+                    "txnid": {
+                        "type": "string",
+                        "description": "Transaction UUID matching the blockchain"
+                    },
+                    "eventout": {
+                        "type": "object",
+                        "description": "The chaincode event emitted on invoke exit, if any",
+                        "properties": {
+                            "asset": {
+                                "$ref": "#/definitions/Model/invokeevent"
+                            }
+                        }
+                    },
+                    "alerts": {
+                        "$ref": "#/definitions/Model/alerts"
+                    },
+                    "compliant": {
+                        "type": "boolean",
+                        "description": "This asset has no active alerts"
+                    }
+                }
+            },
+            "assetstateexternal": {
+                "type": "object",
+                "patternProperties": {
+                    "^DEF": {
+                        "type": "object",
+                        "description": "The external state of one asset asset, named by its world state ID",
+                        "$ref": "#/definitions/Model/assetstate"
+                    }
+                }
+            },
+            "stateFilter": {
+                "type": "object",
+                "description": "Filter asset states",
+                "properties": {
+                    "match": {
+                        "type": "string",
+                        "description": "Defines how to match properties, missing property always fails match",
+                        "enum": [
+                            "n/a",
+                            "all",
+                            "any",
+                            "none"
+                        ]
+                    },
+                    "select": {
+                        "type": "array",
+                        "description": "Qualified property names and values match",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "qprop": {
+                                    "type": "string",
+                                    "description": "Qualified property to compare, for example 'asset.assetID'"
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "description": "Value to be compared"
+                                }
                             }
                         }
                     }
                 }
-            }
-        },
-        "assetstatearray": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/assetstateexternal"
             },
-            "minItems": 0,
-            "description": "Array of asset states, can mix asset classes"
-        },
-        "contractState": {
-            "type": "object",
-            "properties": {
-                "version": {
-                    "$ref": "#/definitions/version"
+            "dateRange": {
+                "type": "object",
+                "description": "if specified, dates must fall in between these values, inclusive",
+                "properties": {
+                    "begin": {
+                        "type": "string",
+                        "description": "timestamp formatted yyyy-mm-dd hh:mm:ss",
+                        "format": "date-time",
+                        "sample": "yyyy-mm-dd hh:mm:ss"
+                    },
+                    "end": {
+                        "type": "string",
+                        "description": "timestamp formatted yyyy-mm-dd hh:mm:ss",
+                        "format": "date-time",
+                        "sample": "yyyy-mm-dd hh:mm:ss"
+                    }
+                }
+            },
+            "assetstatearray": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/Model/assetstate"
                 },
-                "nickname": {
-                    "$ref": "#/definitions/nickname"
+                "minItems": 0,
+                "description": "Array of asset states, can mix asset classes"
+            },
+            "contractState": {
+                "type": "object",
+                "properties": {
+                    "version": {
+                        "$ref": "#/definitions/Model/version"
+                    },
+                    "nickname": {
+                        "$ref": "#/definitions/Model/nickname"
+                    }
                 }
             }
         }


### PR DESCRIPTION
— two separate sections in schema “API”, and “Model”
— Model layer was added in order to separately include and extend
— cleaned up issues with replacing of references (rewrite)
— handled funky array as map format for props (monitoring UI)
— save the previous command in the monitoring UI, much better for
testing